### PR TITLE
Clearing board on game end

### DIFF
--- a/frontend/src/pages/ttt/ttt.ts
+++ b/frontend/src/pages/ttt/ttt.ts
@@ -169,6 +169,9 @@ async function handleTTT(): Promise<RouteHandlerReturn> {
 
             socket.on('gameEnd', () => {
                 curGame = null;
+                for (let idx = 0 ; idx < 9 ; idx++) {
+                    cells[idx].innerText = " ";
+                };
                 currentPlayerTimer.innerText = "Waiting for match...";
                 joinQueueBtn.innerText = QueueState.Idle;
             })


### PR DESCRIPTION
On @AlphanumericString demand, I added board clearing mechanism when a game ends, so as not to be left with a filled grid once the game has ended.